### PR TITLE
use circleci workflows to allow filtering out gh-pages branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     working_directory: ~/oysteR
@@ -23,3 +23,10 @@ jobs:
       - store_artifacts:
           path: ~/oysteR/built/
 
+workflows:
+  workflow-build:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore: gh-pages


### PR DESCRIPTION
Make circleci build ignore changes made to the `gh-pages` branch

cc @bhamail / @DarthHater / @brittanybelle / @adrianpowell / @csgillespie 
