### PR TITLE
Modify generate_purls to better handle missing versions. 

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -23,7 +23,27 @@ generate_purls = function(pkg, version, type) {
   # List format required for httr call
   # The list translates to the body of the curl call
   # Each purl must be it's own list element hence the use of as.list over list
-  purls = as.list(paste0("pkg:", type, "/", pkg, "@", version))
+  # if version is missing, creates "@NA" this searches all. Alternatively could use @*
+  # it will check for all versions of packages in this case
+  no_missing_versions <- sum(is.na(version))
+  missing_pkgs <- pkg[is.na(version)]
+
+  # create alert if missing versions
+  if (no_missing_versions > 0) {
+    missing_msg <- sprintf("%i packages missing versions: %s",
+                           no_missing_versions, paste0(missing_pkgs, collapse = ", "))
+
+    cli_alert_warning(missing_msg)
+    cli_alert_warning(glue::glue("oysteR will check {style_italic('all')} package verions."))
+    cli_alert_warning("This may result in false positives.")
+
+  }
+
+
+  # generate purls
+  purls <- as.list(paste0("pkg:", type, "/", pkg, "@", version))
+
+  # return purls
   return(purls)
 }
 


### PR DESCRIPTION
When a package is missing a version OSS Index is searched for _all_ package versions. This can lead to false positive vulnerability reports. This PR adds a warning in the event of missing package versions



This pull request makes the following changes:
* Adds check to the internal function `generate_purls()` to identify missing package versions
* The function now generates a message in the console via `cli_*()* functions if packages are missing versions 

There should be no breaking changes or changes to existing behavior.

cc @bhamail / @DarthHater / @brittanybelle / @adrianpowell / @csgillespie 
