### PR TITLE
feat: Add support for custom OSS Index URL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# oysteR (development version)
+  * feat: Add support for custom OSS Index URL via parameter, environment variable, or config file
+
 # oysteR 0.1.4 _2025-10-08_
   * bug: Incorrectly states how many packages were found in the database (see #62)
   * feat: Pass tokens as arguments

--- a/R/audit.R
+++ b/R/audit.R
@@ -26,6 +26,8 @@
 #' @param token If NULL, looks at OSSINDEX_USER & OSSINDEX_TOKEN, env variables. If those
 #' aren't available, try `"~/.ossindex/.oss-index-config"`
 #' @param verbose Default \code{TRUE}.
+#' @param ossindex_url Optional custom OSS Index URL. If NULL, looks at OSSINDEX_URL env variable,
+#' then `"~/.ossindex/.oss-index-config"`, then defaults to "https://ossindex.sonatype.org/api/v3/component-report"
 #'
 #' @export
 #' @examples
@@ -34,7 +36,7 @@
 #' version = c("1.4-5", "1.4.1")
 #' audit(pkg, version, type = "cran")
 #' }
-audit = function(pkg, version, type, verbose = TRUE, token = NULL) {
+audit = function(pkg, version, type, verbose = TRUE, token = NULL, ossindex_url = NULL) {
   if (is.null(pkg)) {
     pkg = character(0)
   }
@@ -56,7 +58,7 @@ audit = function(pkg, version, type, verbose = TRUE, token = NULL) {
   pkgs = tibble::tibble(package = pkg, version = version, type = type)[!is_cached, ]
 
   ## Call OSS index on remaining
-  results = call_oss_index(purls, verbose = verbose, token = token)
+  results = call_oss_index(purls, verbose = verbose, token = token, ossindex_url = ossindex_url)
   audit = dplyr::bind_cols(pkgs, results)
 
   # Update cache and combine
@@ -91,7 +93,7 @@ audit = function(pkg, version, type, verbose = TRUE, token = NULL) {
 #' # This calls installed.packages()
 #' pkgs = audit_installed_r_pkgs()
 #' }
-audit_installed_r_pkgs = function(verbose = TRUE, token = NULL) {
+audit_installed_r_pkgs = function(verbose = TRUE, token = NULL, ossindex_url = NULL) {
   pkgs = get_r_pkgs(verbose = verbose)
-  audit(pkg = pkgs$package, version = pkgs$version, type = "cran", verbose = verbose, token = token)
+  audit(pkg = pkgs$package, version = pkgs$version, type = "cran", verbose = verbose, token = token, ossindex_url = ossindex_url)
 }

--- a/R/call_os_index.R
+++ b/R/call_os_index.R
@@ -98,7 +98,7 @@ globalVariables("vulnerabilities")
 #' @importFrom purrr map map_dbl
 #' @importFrom dplyr %>%
 #' @keywords internal
-call_oss_index = function(purls, verbose, token) {
+call_oss_index = function(purls, verbose, token, ossindex_url = NULL) {
   if (length(purls) == 0L) {
     return(no_purls_case())
   }
@@ -107,7 +107,7 @@ call_oss_index = function(purls, verbose, token) {
   }
 
   max_size = 128
-  os_index_url = "https://ossindex.sonatype.org/api/v3/component-report"
+  os_index_url = get_ossindex_url(ossindex_url)
   token = get_token(token, verbose)
   authenticate = httr::authenticate(token$user, token$token, type = "basic")
   user_agent = get_user_agent()

--- a/R/expect_secure.R
+++ b/R/expect_secure.R
@@ -19,7 +19,7 @@
 #'  # Typically used inside testthat
 #'  oysteR::expect_secure("oysteR")
 #' }
-expect_secure = function(pkg, repo = "https://cran.rstudio.com", verbose = FALSE) {
+expect_secure = function(pkg, repo = "https://cran.rstudio.com", verbose = FALSE, ossindex_url = NULL) {
   ## Need to set the repo, as testthat seems to strip this out?
   repos = getOption("repos")
   on.exit(options(repos = repos))
@@ -27,7 +27,7 @@ expect_secure = function(pkg, repo = "https://cran.rstudio.com", verbose = FALSE
 
   ## Look up vulnerabilities
   pkg_loc = system.file("DESCRIPTION", package = pkg)
-  aud = audit_description(dirname(pkg_loc), verbose = verbose)
+  aud = audit_description(dirname(pkg_loc), verbose = verbose, ossindex_url = ossindex_url)
   no_of_vul = sum(aud$no_of_vulnerabilities)
 
   ## Report results

--- a/R/file_audits.R
+++ b/R/file_audits.R
@@ -41,7 +41,8 @@ get_pkg_deps = function(pkgs) {
 audit_description = function(
   dir = ".",
   fields = c("Depends", "Imports", "Suggests"),
-  verbose = TRUE
+  verbose = TRUE,
+  ossindex_url = NULL
 ) {
   ## Read DESCRIPTION and extract fields
   fname = check_file_exists(dir, "DESCRIPTION")
@@ -58,7 +59,7 @@ audit_description = function(
   pkgs = inst_pkgs[rownames(inst_pkgs) %in% all_dep, "Version"]
   versions = as.vector(pkgs)
   pkgs = names(pkgs)
-  audit(pkgs, versions, type = "CRAN", verbose = verbose)
+  audit(pkgs, versions, type = "CRAN", verbose = verbose, ossindex_url = ossindex_url)
 }
 
 #' Audit an renv.lock File
@@ -70,6 +71,7 @@ audit_description = function(
 #'
 #' @param dir The file path of an renv.lock file.
 #' @param verbose Default \code{TRUE}.
+#' @param ossindex_url Optional custom OSS Index URL. If NULL, uses default or configured URL.
 #'
 #' @importFrom jsonlite read_json
 #' @importFrom dplyr %>% mutate
@@ -82,11 +84,11 @@ audit_description = function(
 #' # Looks for renv.lock file in dir
 #' audit_renv_lock(dir = ".")
 #' }
-audit_renv_lock = function(dir = ".", verbose = TRUE) {
+audit_renv_lock = function(dir = ".", verbose = TRUE, ossindex_url = NULL) {
   fname = check_file_exists(dir, "renv.lock")
   renv_lock = jsonlite::read_json(fname)
   renv_pkgs = purrr::map_chr(renv_lock$Packages, purrr::pluck, "Version")
-  audit(pkg = names(renv_pkgs), version = renv_pkgs, type = "cran", verbose = verbose)
+  audit(pkg = names(renv_pkgs), version = renv_pkgs, type = "cran", verbose = verbose, ossindex_url = ossindex_url)
 }
 
 #' Audit a requirements.txt File
@@ -111,12 +113,12 @@ audit_renv_lock = function(dir = ".", verbose = TRUE) {
 #' # Looks for a requirements.txt file in dir
 #' audit_description(dir = ".")
 #' }
-audit_req_txt = function(dir = ".", verbose = TRUE) {
+audit_req_txt = function(dir = ".", verbose = TRUE, ossindex_url = NULL) {
   fname = check_file_exists(dir, "requirements.txt")
   audit = readLines(fname) %>%
     strsplit(">=|==|>") %>%
     map_dfr(~ tibble::tibble(package = .x[1], version = .x[2])) %>%
-    mutate(audit(pkg = .data$package, version = .data$version, type = "pypi", verbose = verbose))
+    mutate(audit(pkg = .data$package, version = .data$version, type = "pypi", verbose = verbose, ossindex_url = ossindex_url))
   return(audit)
 }
 
@@ -129,6 +131,7 @@ audit_req_txt = function(dir = ".", verbose = TRUE) {
 #' @param dir The directory containing a Conda environment yaml file.
 #' @param fname The file name of conda environment yaml file.
 #' @param verbose Default \code{TRUE}.
+#' @param ossindex_url Optional custom OSS Index URL. If NULL, uses default or configured URL.
 #'
 #' @importFrom purrr keep map map_dfr pluck discard
 #' @importFrom rlang .data
@@ -139,7 +142,7 @@ audit_req_txt = function(dir = ".", verbose = TRUE) {
 #' # Looks for a environment.yml file in dir
 #' audit_conda(dir = ".")
 #' }
-audit_conda = function(dir = ".", fname = "environment.yml", verbose = TRUE) {
+audit_conda = function(dir = ".", fname = "environment.yml", verbose = TRUE, ossindex_url = NULL) {
   # check if file exists if it does create file path
   # allow for fname because conda envs are not always title `environment.yml`
   env_fname = check_file_exists(dir, fname)
@@ -166,7 +169,7 @@ audit_conda = function(dir = ".", fname = "environment.yml", verbose = TRUE) {
   }
 
   all_deps = dplyr::bind_rows(conda_deps, pip_deps)
-  aud = audit(all_deps$package, all_deps$version, all_deps$type, verbose = verbose)
+  aud = audit(all_deps$package, all_deps$version, all_deps$type, verbose = verbose, ossindex_url = ossindex_url)
 
   return(aud)
 }

--- a/R/get_token.R
+++ b/R/get_token.R
@@ -19,3 +19,27 @@ get_token = function(token, verbose = TRUE) {
   }
   token
 }
+
+get_ossindex_url = function(ossindex_url = NULL) {
+  # If URL is explicitly provided, use it
+  if (!is.null(ossindex_url)) {
+    return(ossindex_url)
+  }
+
+  # Check environment variable
+  env_url = Sys.getenv("OSSINDEX_URL", NA)
+  if (!is.na(env_url)) {
+    return(env_url)
+  }
+
+  # Check config file
+  if (file.exists("~/.ossindex/.oss-index-config")) {
+    config = yaml::read_yaml("~/.ossindex/.oss-index-config")
+    if (!is.null(config$ossi$Url)) {
+      return(config$ossi$Url)
+    }
+  }
+
+  # Default URL
+  return("https://ossindex.sonatype.org/api/v3/component-report")
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -75,7 +75,7 @@ Set the following environment variables in your `.Renviron` file:
 
   - `OSSINDEX_USER` (this is set to your email address)
   - `OSSINDEX_TOKEN` (this is set to your API token)
-  
+
 Or create a config file at `~/.ossindex/.oss-index-config` and add
 ```
 # This config file is picked up by other Sonatype apps
@@ -85,6 +85,30 @@ ossi:
 ```
 
 These will be used by `{oysteR}` to authenticate with OSS Index, bumping up the amount of requests you can make.
+
+### Custom OSS Index URL
+
+If you need to use a custom OSS Index server (e.g., for enterprise deployments), you can override the default URL in three ways:
+
+1. **Pass as a parameter** (highest priority):
+```{r, eval = FALSE}
+audit_installed_r_pkgs(ossindex_url = "https://custom.ossindex.org/api/v3/component-report")
+```
+
+2. **Set environment variable** in your `.Renviron` file:
+```
+OSSINDEX_URL=https://custom.ossindex.org/api/v3/component-report
+```
+
+3. **Add to config file** at `~/.ossindex/.oss-index-config`:
+```
+ossi:
+   Username: XXXX
+   Token: YYY
+   Url: https://custom.ossindex.org/api/v3/component-report
+```
+
+The parameter takes precedence over the environment variable, which takes precedence over the config file.
 
 ## Contributing
 

--- a/tests/testthat/test-get_token.R
+++ b/tests/testthat/test-get_token.R
@@ -2,3 +2,38 @@ test_that("Check tokens", {
   l = list(username = "ABC", token = "ANC")
   expect_equal(get_token(l), l)
 })
+
+test_that("Check default OSS Index URL", {
+  # Default URL should be returned when no custom URL is provided
+  default_url = "https://ossindex.sonatype.org/api/v3/component-report"
+  expect_equal(get_ossindex_url(), default_url)
+})
+
+test_that("Check custom OSS Index URL parameter", {
+  # Custom URL passed as parameter should be returned
+  custom_url = "https://custom.ossindex.org/api/v3/component-report"
+  expect_equal(get_ossindex_url(custom_url), custom_url)
+})
+
+test_that("Check OSS Index URL from environment variable", {
+  # Set environment variable
+  custom_url = "https://env.ossindex.org/api/v3/component-report"
+  withr::with_envvar(
+    c(OSSINDEX_URL = custom_url),
+    {
+      expect_equal(get_ossindex_url(), custom_url)
+    }
+  )
+})
+
+test_that("Parameter takes precedence over environment variable", {
+  # Parameter should override environment variable
+  param_url = "https://param.ossindex.org/api/v3/component-report"
+  env_url = "https://env.ossindex.org/api/v3/component-report"
+  withr::with_envvar(
+    c(OSSINDEX_URL = env_url),
+    {
+      expect_equal(get_ossindex_url(param_url), param_url)
+    }
+  )
+})


### PR DESCRIPTION
## Summary

This PR adds the ability for users to override the default OSS Index URL, enabling support for custom/enterprise OSS Index servers.

### Changes Made

- **New helper function**: Added `get_ossindex_url()` with priority-based configuration:
  1. Direct parameter (highest priority)
  2. `OSSINDEX_URL` environment variable
  3. `Url` field in `~/.ossindex/.oss-index-config`
  4. Default OSS Index URL (fallback)

- **Updated all audit functions** to accept optional `ossindex_url` parameter:
  - `audit()`
  - `audit_installed_r_pkgs()`
  - `audit_description()`
  - `audit_renv_lock()`
  - `audit_req_txt()`
  - `audit_conda()`
  - `expect_secure()`

- **Updated `call_oss_index()`** to use the configurable URL

- **Comprehensive tests** added to `tests/testthat/test-get_token.R`:
  - Default URL behavior
  - Custom URL via parameter
  - Custom URL via environment variable
  - Parameter precedence over environment variable

- **Documentation updates**:
  - Updated `README.Rmd` with usage examples
  - Added entry to `NEWS.md`

### Usage Examples

**Via parameter:**
```r
audit_installed_r_pkgs(ossindex_url = "https://custom.ossindex.org/api/v3/component-report")
```

**Via environment variable:**
```r
Sys.setenv(OSSINDEX_URL = "https://custom.ossindex.org/api/v3/component-report")
audit_installed_r_pkgs()
```

**Via config file** (`~/.ossindex/.oss-index-config`):
```yaml
ossi:
   Username: your@email.com
   Token: your-token
   Url: https://custom.ossindex.org/api/v3/component-report
```

### Testing

- Unit tests added and will be verified by CI
- Follows the same pattern as the existing token configuration

### Related

This implements the same URL override capability that exists in other Sonatype OSS Index tools (e.g., auditjs), ensuring consistency across the ecosystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)