### PR TITLE
Add support for Sonatype Guide Personal Access Tokens

### DIFF
--- a/R/call_os_index.R
+++ b/R/call_os_index.R
@@ -20,8 +20,9 @@ check_status_code = function(r) {
   status_code = httr::status_code(r)
   if (status_code == 401) {
     stop(
-      "Invalid credentials for OSS Index.
-         Please check your username and API token and try again.",
+      "Invalid credentials.
+         Please check your OSSINDEX_TOKEN (Guide PAT) or
+         OSSINDEX_USER/OSSINDEX_TOKEN (legacy OSS Index credentials) and try again.",
       call. = FALSE
     ) # nocov
   } else if (status_code == 429) {
@@ -107,9 +108,15 @@ call_oss_index = function(purls, verbose, token) {
   }
 
   max_size = 128
-  os_index_url = "https://ossindex.sonatype.org/api/v3/component-report"
-  token = get_token(token, verbose)
-  authenticate = httr::authenticate(token$user, token$token, type = "basic")
+  token    = get_token(token, verbose)
+
+  if (!is.null(token) && token$type == "bearer") {
+    os_index_url = "https://api.guide.sonatype.com/api/v3/component-report"
+    authenticate = httr::add_headers(Authorization = paste("Bearer", token$token))
+  } else {
+    os_index_url = "https://ossindex.sonatype.org/api/v3/component-report"
+    authenticate = httr::authenticate(token$user, token$token, type = "basic")
+  }
   user_agent = get_user_agent()
   no_of_batches = ceiling(length(purls) / max_size)
   results = list()

--- a/R/get_token.R
+++ b/R/get_token.R
@@ -1,13 +1,15 @@
 get_token = function(token, verbose = TRUE) {
   if (is.null(token)) {
     user = Sys.getenv("OSSINDEX_USER", NA)
-    token = Sys.getenv("OSSINDEX_TOKEN", NA)
-    if (!is.na(user) && !is.na(token)) {
-      token = list(user = user, token = token)
+    tok  = Sys.getenv("OSSINDEX_TOKEN", NA)
+    if (!is.na(tok)) {
+      token = list(type = "bearer", token = tok)
+    } else if (file.exists("~/.ossindex/.oss-index-config")) {
+      config = yaml::read_yaml("~/.ossindex/.oss-index-config")
+      token  = list(type = "basic",
+                    user  = config$ossi$Username,
+                    token = config$ossi$Token)
     }
-  } else if (is.null(token) && file.exists("~/.ossindex/.oss-index-config")) {
-    config = yaml::read_yaml("~/.ossindex/.oss-index-config")
-    token = list(user = config$ossi$Username, token = config$ossi$Token)
   }
 
   if (isTRUE(verbose)) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -68,14 +68,12 @@ Remember to add {oysteR} under Suggests in your DESCRIPTION file.
 
 Heavy use against OSS Index will likely run you into rate limiting (yikes!), but you can:
 
-- Register for an account on [OSS Index](https://ossindex.sonatype.org/)
-- Retrieve your API token after registering (on the User Settings page)
+- Register for a free account on [Sonatype Guide](https://guide.sonatype.com) and generate a Personal Access Token at [guide.sonatype.com/settings/tokens](https://guide.sonatype.com/settings/tokens)
 
-Set the following environment variables in your `.Renviron` file:
+Set the following environment variable in your `.Renviron` file:
 
-  - `OSSINDEX_USER` (this is set to your email address)
-  - `OSSINDEX_TOKEN` (this is set to your API token)
-  
+  - `OSSINDEX_TOKEN` (your Sonatype Guide Personal Access Token)
+
 Or create a config file at `~/.ossindex/.oss-index-config` and add
 ```
 # This config file is picked up by other Sonatype apps

--- a/README.md
+++ b/README.md
@@ -67,15 +67,14 @@ add {oysteR} under Suggests in your DESCRIPTION file.
 Heavy use against OSS Index will likely run you into rate limiting
 (yikes!), but you can:
 
--   Register for an account on [OSS
-    Index](https://ossindex.sonatype.org/)
--   Retrieve your API token after registering (on the User Settings
-    page)
+-   Register for a free account on [Sonatype
+    Guide](https://guide.sonatype.com) and generate a Personal Access
+    Token at
+    [guide.sonatype.com/settings/tokens](https://guide.sonatype.com/settings/tokens)
 
-Set the following environment variables in your `.Renviron` file:
+Set the following environment variable in your `.Renviron` file:
 
--   `OSSINDEX_USER` (this is set to your email address)
--   `OSSINDEX_TOKEN` (this is set to your API token)
+-   `OSSINDEX_TOKEN` (your Sonatype Guide Personal Access Token)
 
 Or create a config file at `~/.ossindex/.oss-index-config` and add
 

--- a/tests/testthat/test-get_token.R
+++ b/tests/testthat/test-get_token.R
@@ -1,4 +1,43 @@
-test_that("Check tokens", {
-  l = list(username = "ABC", token = "ANC")
+test_that("get_token returns token as-is when already a list", {
+  l = list(type = "bearer", token = "mytoken")
   expect_equal(get_token(l), l)
+})
+
+test_that("get_token returns bearer token when only OSSINDEX_TOKEN is set", {
+  old_user  = Sys.getenv("OSSINDEX_USER")
+  old_token = Sys.getenv("OSSINDEX_TOKEN")
+  Sys.unsetenv("OSSINDEX_USER")
+  Sys.setenv(OSSINDEX_TOKEN = "mytoken")
+
+  t = get_token(NULL, verbose = FALSE)
+  expect_equal(t$type, "bearer")
+  expect_equal(t$token, "mytoken")
+
+  if (nchar(old_user)  > 0) Sys.setenv(OSSINDEX_USER  = old_user)
+  if (nchar(old_token) > 0) Sys.setenv(OSSINDEX_TOKEN = old_token) else Sys.unsetenv("OSSINDEX_TOKEN")
+})
+
+test_that("get_token returns bearer token when both OSSINDEX_USER and OSSINDEX_TOKEN are set", {
+  old_user  = Sys.getenv("OSSINDEX_USER")
+  old_token = Sys.getenv("OSSINDEX_TOKEN")
+  Sys.setenv(OSSINDEX_USER = "user@example.com", OSSINDEX_TOKEN = "mytoken")
+
+  t = get_token(NULL, verbose = FALSE)
+  expect_equal(t$type, "bearer")
+  expect_equal(t$token, "mytoken")
+
+  if (nchar(old_user)  > 0) Sys.setenv(OSSINDEX_USER  = old_user) else Sys.unsetenv("OSSINDEX_USER")
+  if (nchar(old_token) > 0) Sys.setenv(OSSINDEX_TOKEN = old_token) else Sys.unsetenv("OSSINDEX_TOKEN")
+})
+
+test_that("get_token returns NULL when no credentials are set", {
+  old_user  = Sys.getenv("OSSINDEX_USER")
+  old_token = Sys.getenv("OSSINDEX_TOKEN")
+  Sys.unsetenv("OSSINDEX_USER")
+  Sys.unsetenv("OSSINDEX_TOKEN")
+
+  expect_null(get_token(NULL, verbose = FALSE))
+
+  if (nchar(old_user)  > 0) Sys.setenv(OSSINDEX_USER  = old_user)
+  if (nchar(old_token) > 0) Sys.setenv(OSSINDEX_TOKEN = old_token)
 })


### PR DESCRIPTION
### Brief overview
My CI pipeline was crashing due to issue #80 - this commit solves it. 
Apparently `OSS Index will migrate to Sonatype Guide on 04/28` - so this fix will be necessary for ossindex users as well in the future. 
Here is the migration advisory: 
https://www.sonatype.com/products/sonatype-guide/oss-index-users?utm_source=product&utm_medium=banner&utm_campaign=OSSI

oysteR was using Basic Auth against the legacy `ossindex.sonatype.org`
endpoint, which does not accept Sonatype Guide Personal Access Tokens (PATs),
causing 401 errors for users who have migrated to Guide. This PR adds Bearer
auth support against the new `api.guide.sonatype.com` endpoint.

### This pull request makes the following changes:
- `R/get_token.R`: Use Bearer auth when `OSSINDEX_TOKEN` is set. Also fixes a
  dead-code bug where the YAML config file branch was unreachable.
- `R/call_os_index.R`: Route Bearer auth requests to `api.guide.sonatype.com`.
  Legacy YAML config Basic Auth still routes to the old endpoint for backwards
  compatibility. Updated 401 error message.
- `tests/testthat/test-get_token.R`: Added tests for bearer token, both env
  vars set, and null credential cases.
- `README.Rmd` / `README.md`: Updated authentication section to reference
  Sonatype Guide PAT instead of legacy OSS Index credentials.

It relates to the following issue #80 :
- Fixes #80 

cc @bhamail / @DarthHater / @brittanybelle / @csgillespie